### PR TITLE
Fix async animate on unexpcted loop exit

### DIFF
--- a/clanim/animation/animation.py
+++ b/clanim/animation/animation.py
@@ -7,7 +7,8 @@
 """
 import itertools
 import functools
-from ..util import concatechain, BACKSPACE_GEN, BACKLINE_GEN, BACKSPACE, BACKLINE
+from ..util import concatechain, BACKSPACE_GEN, BACKLINE_GEN
+from ..cli import BACKLINE, BACKSPACE
 from .alnum import big_message
 
 class _Animation:


### PR DESCRIPTION
Async animate now shuts down properly, given that the event loop is shut down gracefully (i.e. `asyncio.get_event_loop().close()` is called).